### PR TITLE
fix: allow all methods and origins (while not using public api) #8

### DIFF
--- a/infrared_wrapper_api/api/main.py
+++ b/infrared_wrapper_api/api/main.py
@@ -1,5 +1,6 @@
 import uvicorn
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware 
 
 from infrared_wrapper_api.api.endpoints import router as tasks_router
 from infrared_wrapper_api.config import settings
@@ -9,6 +10,21 @@ app = FastAPI(
     descriprition=settings.description,
     version=settings.version,
 )
+
+origins = [
+    # "http://localhost",
+    # "http://localhost:8080",
+    "*"
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 
 
 @app.get("/health_check", tags=["ROOT"])


### PR DESCRIPTION
we can revert this after we switch to the public api